### PR TITLE
safeMode to allow raw GitHub and Stash includes

### DIFF
--- a/adoc.velocity
+++ b/adoc.velocity
@@ -50,6 +50,8 @@ jQuery(function() {
             {
                 doctype: 'article',
                 backend: 'html5',
+##              Adding safeMode will allow us to directly include Stash and Git Raw files in the macro:
+                safeMode: 'safe',
 
 ##              If you want to implement any default attributes, enter them below (showtitle shows the root adoc title):
                 attributes: ['showtitle']


### PR DESCRIPTION
I've added the parameter `safeMode: 'safe'` which should let us use the `include::` directive in the adoc macro to suck in raw GitHub or Stash .adoc files. 

This would mean we could single source in Stash and pump in files where we needed them in Confluence.
